### PR TITLE
Fixed title in header to display company name.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="./assets/css/style.css">
-    <title>website</title>
+    <title>Horiseon Website</title>
 </head>
 
 <body>


### PR DESCRIPTION
Starter code had the title in the header as "website." This was showing up each time site was opened in live server. In order to better optimize accessibility, I fixed the title name from "website" to "Horiseon Website."